### PR TITLE
Compare fields sizing/alignment

### DIFF
--- a/src/com/smanis/coffee/forms/RoastLogEdit.form
+++ b/src/com/smanis/coffee/forms/RoastLogEdit.form
@@ -13,7 +13,7 @@
     <Property name="resizable" type="boolean" value="false"/>
   </Properties>
   <SyntheticProperties>
-    <SyntheticProperty name="formSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,3,59,0,0,4,-54"/>
+    <SyntheticProperty name="formSize" type="java.awt.Dimension" value="-84,-19,0,5,115,114,0,18,106,97,118,97,46,97,119,116,46,68,105,109,101,110,115,105,111,110,65,-114,-39,-41,-84,95,68,20,2,0,2,73,0,6,104,101,105,103,104,116,73,0,5,119,105,100,116,104,120,112,0,0,3,59,0,0,4,-115"/>
     <SyntheticProperty name="formSizePolicy" type="int" value="0"/>
     <SyntheticProperty name="generateSize" type="boolean" value="true"/>
     <SyntheticProperty name="generateCenter" type="boolean" value="true"/>
@@ -60,7 +60,7 @@
       </Properties>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-          <AbsoluteConstraints x="10" y="50" width="420" height="340"/>
+          <AbsoluteConstraints x="10" y="50" width="420" height="320"/>
         </Constraint>
       </Constraints>
 
@@ -362,7 +362,7 @@
           </Properties>
           <Constraints>
             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-              <AbsoluteConstraints x="20" y="290" width="380" height="30"/>
+              <AbsoluteConstraints x="20" y="280" width="380" height="30"/>
             </Constraint>
           </Constraints>
         </Component>
@@ -1086,7 +1086,7 @@
       </Events>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-          <AbsoluteConstraints x="920" y="740" width="-1" height="-1"/>
+          <AbsoluteConstraints x="900" y="740" width="-1" height="-1"/>
         </Constraint>
       </Constraints>
     </Component>
@@ -1103,7 +1103,7 @@
       </Events>
       <Constraints>
         <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout" value="org.netbeans.modules.form.compat2.layouts.DesignAbsoluteLayout$AbsoluteConstraintsDescription">
-          <AbsoluteConstraints x="1030" y="740" width="-1" height="-1"/>
+          <AbsoluteConstraints x="1020" y="740" width="-1" height="-1"/>
         </Constraint>
       </Constraints>
     </Component>

--- a/src/com/smanis/coffee/forms/RoastLogEdit.java
+++ b/src/com/smanis/coffee/forms/RoastLogEdit.java
@@ -260,9 +260,9 @@ public class RoastLogEdit extends javax.swing.JDialog {
         labelComparePercentage.setMaximumSize(new java.awt.Dimension(94, 32));
         labelComparePercentage.setMinimumSize(new java.awt.Dimension(94, 32));
         labelComparePercentage.setPreferredSize(new java.awt.Dimension(94, 32));
-        panelRoastDate.add(labelComparePercentage, new org.netbeans.lib.awtextra.AbsoluteConstraints(20, 290, 380, 30));
+        panelRoastDate.add(labelComparePercentage, new org.netbeans.lib.awtextra.AbsoluteConstraints(20, 280, 380, 30));
 
-        getContentPane().add(panelRoastDate, new org.netbeans.lib.awtextra.AbsoluteConstraints(10, 50, 420, 340));
+        getContentPane().add(panelRoastDate, new org.netbeans.lib.awtextra.AbsoluteConstraints(10, 50, 420, 320));
 
         panelTimes.setBorder(javax.swing.BorderFactory.createBevelBorder(javax.swing.border.BevelBorder.LOWERED));
         panelTimes.setLayout(new org.netbeans.lib.awtextra.AbsoluteLayout());
@@ -552,7 +552,7 @@ public class RoastLogEdit extends javax.swing.JDialog {
                 btnCancelActionPerformed(evt);
             }
         });
-        getContentPane().add(btnCancel, new org.netbeans.lib.awtextra.AbsoluteConstraints(920, 740, -1, -1));
+        getContentPane().add(btnCancel, new org.netbeans.lib.awtextra.AbsoluteConstraints(900, 740, -1, -1));
 
         btnSave.setFont(new java.awt.Font("Dialog.plain", 0, 20)); // NOI18N
         btnSave.setMnemonic('v');
@@ -562,9 +562,9 @@ public class RoastLogEdit extends javax.swing.JDialog {
                 btnSaveActionPerformed(evt);
             }
         });
-        getContentPane().add(btnSave, new org.netbeans.lib.awtextra.AbsoluteConstraints(1030, 740, -1, -1));
+        getContentPane().add(btnSave, new org.netbeans.lib.awtextra.AbsoluteConstraints(1020, 740, -1, -1));
 
-        setSize(new java.awt.Dimension(1226, 827));
+        setSize(new java.awt.Dimension(1165, 827));
         setLocationRelativeTo(null);
     }// </editor-fold>//GEN-END:initComponents
 


### PR DESCRIPTION
- Shrunk size of Roast Level and Percentage/weights comparative display labels.
- Adusted containing panel size.
- Save/Cancel button realignment and decreased panel width.